### PR TITLE
Fix task labels lookup

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -221,7 +221,7 @@ func taskLabels(task swarm.Task, serviceIDMap map[string]swarm.Service) map[stri
 		model.MetaLabelPrefix + "docker_task_name":          task.Name,
 		model.MetaLabelPrefix + "docker_task_desired_state": string(task.DesiredState),
 	}
-	for k, v := range task.Labels {
+	for k, v := range task.Spec.ContainerSpec.Labels {
 		labels[strutil.SanitizeLabelName(model.MetaLabelPrefix+"docker_task_label_"+k)] = v
 	}
 	for k, v := range service.Spec.Labels {


### PR DESCRIPTION
According to #1, the task labels should be used in the target discovery, but the Task object does not have directly a Labels attribute.