### PR TITLE
Ignore exposed ports during explicit discovery mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Usage:
 
 Flags:
   -c, --clean               Disconnects unused networks from the Prometheus container, and deletes them. (default true)
+  -d, --discovery           Discovery time: implicit, explicit. Implicit scans all the services found while explicit scans only labeled services. (default "implicit")
   -i, --interval int        The interval, in seconds, at which the discovery process is kicked off (default 30)
   -l, --loglevel string     Specify log level: debug, info, warn, error (default "info")
   -o, --output string       Output file that contains the Prometheus endpoints. (default "swarm-endpoints.json")


### PR DESCRIPTION
During explicit discovery mode only collect ports specified in label. This is helpful if your container expose some ports not serving metrics. 

Explicit discovery already ignores all containers not labelled `prometheus.scan=true`, with this change you also need to explicitly label containers with the port to collect. `prometheus.port=8080`.